### PR TITLE
Add content property to MoMessage example

### DIFF
--- a/conversations/v3/webhook-events-v2.yaml
+++ b/conversations/v3/webhook-events-v2.yaml
@@ -377,6 +377,9 @@ components:
         to: "49123512315"
         timestamp: 2019-06-26T11:41:00
         channel: viber
+        content:
+          contentType: text
+          text: A simple text message
     MoContent:
       type: object
       description: Content of the mobile-originated message

--- a/conversations/v3/webhook-events-v3.yaml
+++ b/conversations/v3/webhook-events-v3.yaml
@@ -429,6 +429,9 @@ components:
         to: "49123512315"
         timestamp: 2019-06-26T11:41:00
         channel: viber
+        content:
+          contentType: text
+          text: A simple text message
     MoContent:
       type: object
       description: Content of the mobile-originated message


### PR DESCRIPTION
`content` is a required property, so it probably should be present in the example